### PR TITLE
Refactor/favorites

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.where(user_id: current_user.following.ids)
-      .includes(:user, :user_favorites).decorate
+      .includes(:user, :users_who_favorited).decorate
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -43,13 +43,13 @@ class PostsController < ApplicationController
 
   def favorite
     unless current_user.has_favorite?(@post)
-      FavoriteHandler.create(user_id: current_user.id, post_id: @post.id )
+      Favorite.create(user_id: current_user.id, post_id: @post.id )
     end
     redirect_to posts_path
   end
 
   def unfavorite
-    FavoriteHandler.destroy_favorite(current_user.id, @post.id)
+    Favorite.destroy_favorite(current_user.id, @post.id)
     redirect_to posts_path
   end
 

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -4,7 +4,7 @@ class PostDecorator < Draper::Decorator
   decorates :post
 
   def favorite_icon
-    if object.user_favorites.include?(current_user)
+    if object.users_who_favorited.include?(current_user)
       link_to '', unfavorite_post_path(post), method: :delete, class: "glyphicon glyphicon-heart"
     else
       link_to '', favorite_post_path(post), method: :post, class: "glyphicon glyphicon-heart-empty"
@@ -19,12 +19,12 @@ class PostDecorator < Draper::Decorator
 
   def favorites_list
     list = ""
-    if object.user_favorites.empty?
+    if object.users_who_favorited.empty?
       list << "Nobody yet."
     else
       # I'm not sure how to make this work properly
       # html_safe will work, but that opens a XSS vulnerability
-      object.user_favorites.each do |favorite|
+      object.users_who_favorited.each do |favorite|
         list << favorite.username + "<br />"
       end
     end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,4 @@
-class FavoriteHandler < ActiveRecord::Base
+class Favorite < ActiveRecord::Base
   belongs_to :user
   belongs_to :post
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ActiveRecord::Base
   belongs_to :user
-  has_many :favorite_handlers
-  has_many :user_favorites, through: :favorite_handlers, source: "user"
+  has_many :favorites
+  has_many :user_favorites, through: :favorites, source: "user"
 
   validates :user_id, presence: true
   validates :content, length: {maximum: 140}, allow_blank: false

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ActiveRecord::Base
   belongs_to :user
   has_many :favorites
-  has_many :user_favorites, through: :favorites, source: "user"
+  has_many :users_who_favorited, through: :favorites, source: "user"
 
   validates :user_id, presence: true
   validates :content, length: {maximum: 140}, allow_blank: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,8 @@ class User < ActiveRecord::Base
   has_many :following, through: :following_relationships, source: "followed"
   has_many :followers, through: :follower_relationships,  source: "follower"
 
-  has_many :favorite_handlers
-  has_many :favorites, through: :favorite_handlers, source: "post"
+  has_many :favorites
+  has_many :favorite_posts, through: :favorites, source: "post"
 
   validates :username, presence: true, uniqueness: true
   has_attached_file :avatar, styles: {medium: "300x300"}, default_url: "/images/missing.png"
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
   end
 
   def has_favorite?(post)
-    favorites.include?(post)
+    favorite_posts.include?(post)
   end
 
   def avatar_medium

--- a/db/migrate/20160119170248_create_favorite_handlers.rb
+++ b/db/migrate/20160119170248_create_favorite_handlers.rb
@@ -1,6 +1,6 @@
-class CreateFavorites < ActiveRecord::Migration
+class CreateFavoriteHandlers < ActiveRecord::Migration
   def change
-    create_table :favorites do |t|
+    create_table :favorite_handlers do |t|
       t.integer :user_id
       t.integer :post_id
 

--- a/db/migrate/20160119170248_create_favorite_handlers.rb
+++ b/db/migrate/20160119170248_create_favorite_handlers.rb
@@ -1,6 +1,6 @@
-class CreateFavoriteHandlers < ActiveRecord::Migration
+class CreateFavorites < ActiveRecord::Migration
   def change
-    create_table :favorite_handlers do |t|
+    create_table :favorites do |t|
       t.integer :user_id
       t.integer :post_id
 

--- a/db/migrate/20160122202131_rename_favorite_handlers_to_favorites.rb
+++ b/db/migrate/20160122202131_rename_favorite_handlers_to_favorites.rb
@@ -1,0 +1,5 @@
+class RenameFavoriteHandlersToFavorites < ActiveRecord::Migration
+  def change
+    rename_table :favorite_handlers, :favorites
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160119170248) do
+ActiveRecord::Schema.define(version: 20160122202131) do
 
-  create_table "favorite_handlers", force: :cascade do |t|
+  create_table "favorites", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "post_id"
     t.datetime "created_at", null: false

--- a/features/step_definitions/post_steps.rb
+++ b/features/step_definitions/post_steps.rb
@@ -27,7 +27,7 @@ When(/^I try to edit that post$/) do
 end
 
 When(/^I favorite that user's post$/) do
-  FactoryGirl.create(:favorite_handler, user: @current_user, post: @zorldo_post)
+  FactoryGirl.create(:favorite, user: @current_user, post: @zorldo_post)
 end
 
 Then(/^I am listed on the post's show page$/) do

--- a/spec/decorators/post_decorator_spec.rb
+++ b/spec/decorators/post_decorator_spec.rb
@@ -10,7 +10,7 @@ describe PostDecorator do
   describe "#favorite_icon" do
     let(:post) { create(:post).decorate }
     context "post was favorited by current user" do
-      let!(:favorite) {create(:favorite_handler,
+      let!(:favorite) {create(:favorite,
         user: @current_user, post: post)}
       it "should return a full heart" do
         expect(post.favorite_icon).to include("glyphicon-heart")
@@ -49,7 +49,7 @@ describe PostDecorator do
     end
 
     context "post has been favorited by a user" do
-      let!(:favorite) {create(:favorite_handler,
+      let!(:favorite) {create(:favorite,
         user: @current_user, post: post)}
       it "should include the user's name" do
         expect(post.favorites_list).to include(@current_user.username)

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :favorite_handler do
+  factory :favorite do
     user
     post
   end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FavoriteHandler, type: :model do
+RSpec.describe Favorite, type: :model do
   ### Associations
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:post) }
@@ -13,10 +13,10 @@ RSpec.describe FavoriteHandler, type: :model do
   describe ".destroy_favorite(user_id, post_id)" do
     let(:current_user) { create(:user) }
     let(:post) { create(:post) }
-    let!(:favorite) { create(:favorite_handler, user: current_user, post: post) }
+    let!(:favorite) { create(:favorite, user: current_user, post: post) }
     it "should destroy a user favorite" do
-      expect { FavoriteHandler.destroy_favorite(current_user.id, post.id) }.
-        to change(FavoriteHandler, :count).by(-1)
+      expect { Favorite.destroy_favorite(current_user.id, post.id) }.
+        to change(Favorite, :count).by(-1)
     end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Post, type: :model do
   ### Associations
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:favorites) }
-  it { is_expected.to have_many(:user_favorites) }
+  it { is_expected.to have_many(:users_who_favorited) }
 
   ### Validations
   it { is_expected.to validate_presence_of(:user_id) }

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Post, type: :model do
   ### Associations
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:favorite_handlers) }
+  it { is_expected.to have_many(:favorites) }
   it { is_expected.to have_many(:user_favorites) }
 
   ### Validations

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe User, type: :model do
 
       context "when a post is in the user's favorites" do
         let!(:post) { create(:post) }
-        let!(:favorite) { create(:favorite_handler, user: @current_user, post: post) }
+        let!(:favorite) { create(:favorite, user: @current_user, post: post) }
 
         it "returns true" do
           expect(@current_user.has_favorite?(post)).to eq(true)


### PR DESCRIPTION
### Why?

https://github.com/smashingboxes/apprenticeship/tree/master/Curriculum/Backend/twitter
Because developers like names that are clear and self-explanatory
### What Changed?

The FavoriteHandler model was renamed to Favorite.
Previous `has_many :favorites` association has been updated to `has_many :favorite_posts`
